### PR TITLE
Make `QueueName` public.

### DIFF
--- a/FakeSQSQueue.scala
+++ b/FakeSQSQueue.scala
@@ -14,7 +14,7 @@ trait FakeSQSQueue[T] extends SQSQueue[T] {
 
   protected val sqs: AmazonSQSAsync = null
   protected val createIfNotExists: Boolean = false
-  protected val queue: QueueName = QueueName("fake")
+  val queue: QueueName = QueueName("fake")
   protected implicit def asString(obj: T): String = null
   protected implicit def fromString(s: String): T = null
 

--- a/FormattedSQSQueue.scala
+++ b/FormattedSQSQueue.scala
@@ -9,7 +9,7 @@ import scala.language.implicitConversions
 
 class FormattedSQSQueue[T](
     protected val sqs: AmazonSQSAsync,
-    protected val queue: QueueName,
+    val queue: QueueName,
     protected val createIfNotExists: Boolean = false,
     format: Format[T]
   ) extends SQSQueue[T] {

--- a/SQSQueue.scala
+++ b/SQSQueue.scala
@@ -20,24 +20,18 @@ import com.amazonaws.services.sqs.model.{
 }
 import com.amazonaws.handlers.AsyncHandler
 
-
-
-
-
 case class QueueName(name: String)
 
 case class MessageId(id: String)
 
-
 case class SQSMessage[T](body: T, consume: () => Unit, attributes: Map[String,String] = Map.empty)
-
-
 
 trait SQSQueue[T]{
 
+  val queue: QueueName
+
   protected val sqs: AmazonSQSAsync
   protected val createIfNotExists: Boolean
-  protected val queue: QueueName
   protected implicit def asString(obj: T): String
   protected implicit def fromString(s: String): T
 

--- a/SimpleSQSQueue.scala
+++ b/SimpleSQSQueue.scala
@@ -8,12 +8,12 @@ import play.api.libs.json.{JsValue, Json}
 
 
 
-class SimpleSQSQueue(protected val sqs: AmazonSQSAsync, protected val queue: QueueName, protected val createIfNotExists: Boolean = false) extends SQSQueue[String] {
+class SimpleSQSQueue(protected val sqs: AmazonSQSAsync, val queue: QueueName, protected val createIfNotExists: Boolean = false) extends SQSQueue[String] {
   protected implicit def asString(s: String) = s
   protected implicit def fromString(s: String) = s
 }
 
-class JsonSQSQueue(protected val sqs: AmazonSQSAsync, protected val queue: QueueName, protected val createIfNotExists: Boolean = false) extends SQSQueue[JsValue] {
+class JsonSQSQueue(protected val sqs: AmazonSQSAsync, val queue: QueueName, protected val createIfNotExists: Boolean = false) extends SQSQueue[JsValue] {
   protected implicit def asString(json: JsValue) = Json.stringify(json)
   protected implicit def fromString(s: String) = Json.parse(s)
 }


### PR DESCRIPTION
`QueueName` made public so that when we have a queue, we can send the name to another service to load the queue.

@stkem
