### PR TITLE
Adding enumerator with ability for batch requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.kifi"
 
 name := "franz"
 
-version := "0.3.7-SNAPSHOT"
+version := "0.3.8-SNAPSHOT"
 
 crossScalaVersions := Seq("2.10.4", "2.11.5")
 


### PR DESCRIPTION
Can use batch requests with and without a lock. Uses same loop mechanics as the single enumerator.

I have tested this locally and everything works great.

Thanks again for the solid library.