### PR TITLE
Added "See Also" section with a link to a post

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ Current newest version is `0.3.9`. If you are using __sbt__, just add
 ```
 
 to your dependencies and you should be good to go. All classes are in in `com.kifi.franz`.
+
+#See Also
+
+Kifi's Reactive Scala Wrapper for Amazon SQS [blog post](http://eng.kifi.com/reactive-scala-wrapper-for-amazon-sqs/)


### PR DESCRIPTION
The blog [post](http://eng.kifi.com/reactive-scala-wrapper-for-amazon-sqs/) has some nice additional information.  In particular, code differences with the java native client.  Hence it might be beneficial to include a link to it.