### PR TITLE
added a shutdown method to the client and set buffered = false SimpleSQSClient

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.kifi"
 
 name := "franz"
 
-version := "0.3.10"
+version := "0.3.11"
 
 crossScalaVersions := Seq("2.10.4", "2.11.5")
 

--- a/src/main/scala/com/kifi/franz/SQSClient.scala
+++ b/src/main/scala/com/kifi/franz/SQSClient.scala
@@ -8,6 +8,7 @@ trait SQSClient {
   def json(queue: QueueName, createIfNotExists: Boolean=false): SQSQueue[JsValue]
   def formatted[T](queue: QueueName, createIfNotExists: Boolean=false)(implicit format: Format[T]): SQSQueue[T]
   def delete(queue: QueueName): Future[Boolean]
-  def deleteByPrefix(queuePrefix: String)(implicit executor: ExecutionContext): Future[Int] 
+  def deleteByPrefix(queuePrefix: String)(implicit executor: ExecutionContext): Future[Int]
+  def shutdown()
 }
 

--- a/src/main/scala/com/kifi/franz/SimpleSQSClient.scala
+++ b/src/main/scala/com/kifi/franz/SimpleSQSClient.scala
@@ -70,6 +70,11 @@ class SimpleSQSClient(credentialProvider: AWSCredentialsProvider, region: Region
     })
     deletedQueue.future
   }
+
+  def shutdown(): Unit ={
+    this.sqs.shutdown()
+  }
+
 }
 
 object SimpleSQSClient {
@@ -87,7 +92,7 @@ object SimpleSQSClient {
       def getAWSAccessKeyId() = key
       def getAWSSecretKey() = secret
     }
-    this(credentials, region, true)
+    this(credentials, region, false)
   }
 
 }


### PR DESCRIPTION
I added a shutdown method in the SimpleSQSClient and changed the constructor to use buffered = false. It was using buffered = true.

Feel free to merge it or if you don't mind adding the shutdown function and making the change so that the 
apply(key: String, secret: String, region: Regions) method produces the SimpleSQSClient with buffered = false.

Thanks