### PR TITLE
treatment on initQueueUrl if this does not exists

### DIFF
--- a/src/main/scala/com/kifi/franz/SQSQueue.scala
+++ b/src/main/scala/com/kifi/franz/SQSQueue.scala
@@ -45,10 +45,11 @@ trait SQSQueue[T]{
 
   protected val queueUrl: String = initQueueUrl()
   protected def initQueueUrl() = {
-    if (createIfNotExists){
-      sqs.createQueue(new CreateQueueRequest(queue.name)).getQueueUrl
-    } else {
+    try {
       sqs.getQueueUrl(new GetQueueUrlRequest(queue.name)).getQueueUrl
+    } catch {
+      case t: com.amazonaws.services.sqs.model.QueueDoesNotExistException if createIfNotExists => sqs.createQueue(new CreateQueueRequest(queue.name)).getQueueUrl
+      case t: Throwable => throw t
     }
   }
 


### PR DESCRIPTION
I added a treatment at initQueueUrl method if it does not exist because I received a notification of AWS, as follows:
> We noticed an increase in CreateQueue requests from your account in sa-east-1 between 5:00 PM PDT and 6:50 PM PDT on July 22. The CreateQueue requests were attempting to create queues that already exist.
> We believe that you are calling CreateQueue frequently to obtain the QueueUrl each time you attempt to send or receive a message. We recommend that you use the GetQueueUrl API and only use CreateQueue if GetQueueUrl indicates that the queue does not exist.
> If you have a different use case, please let us know. If this particular usage pattern continues we will **enforce throttling** on your CreateQueue API calls.
