### PR TITLE
wrapping JSON parsing with Try

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,16 +131,16 @@ Where ```Format[T]``` and ```JsValue``` are form ```play.api.libs.json```. ```Qu
 #Installation
 
 You can get Franz from maven central. The artifact is `franz_2.10` or `franz_2.11` and the group id is `com.kifi`.
-The current version is `0.3.16`. For example, if you are using __sbt__, just add this to your dependencies:
+The current version is `0.3.17`. For example, if you are using __sbt__, just add this to your dependencies:
 
 ```
-"com.kifi" % "franz_2.11" % "0.3.16"
+"com.kifi" % "franz_2.11" % "0.3.17"
 ```
 
 To add a dependency that matches your scala version (2.10.x or 2.11.x), use
 
 ```
-"com.kifi" %% "franz" % "0.3.16"
+"com.kifi" %% "franz" % "0.3.17"
 ```
 
 All classes are in in `com.kifi.franz`.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.kifi"
 
 name := "franz"
 
-version := "0.3.16"
+version := "0.3.17"
 
 crossScalaVersions := Seq("2.10.4", "2.11.5")
 

--- a/src/main/scala/com/kifi/franz/SimpleSQSQueue.scala
+++ b/src/main/scala/com/kifi/franz/SimpleSQSQueue.scala
@@ -3,8 +3,9 @@ package com.kifi.franz
 import com.amazonaws.services.sqs.AmazonSQSAsync
 
 import scala.language.implicitConversions
+import play.api.libs.json.{JsValue, Json, JsUndefined}
 
-import play.api.libs.json.{JsValue, Json}
+import scala.util.{Failure, Success, Try}
 
 
 
@@ -15,5 +16,10 @@ class SimpleSQSQueue(protected val sqs: AmazonSQSAsync, val queue: QueueName, pr
 
 class JsonSQSQueue(protected val sqs: AmazonSQSAsync, val queue: QueueName, protected val createIfNotExists: Boolean = false) extends SQSQueue[JsValue] {
   protected implicit def asString(json: JsValue) = Json.stringify(json)
-  protected implicit def fromString(s: String) = Json.parse(s)
+  protected implicit def fromString(s: String) = {
+    Try(Json.parse(s)) match {
+      case Success(json) => json
+      case Failure(e) => JsUndefined(e.getMessage)
+    }
+  }
 }


### PR DESCRIPTION
In the event that an SQS queue receives a non-JSON value, JsonSQSQueue
won't fail with an exception on read and will instead return
JsUndefined. Consumers of the queue can then safely work with a JsValue
type.