### PR TITLE
adding a waitTimeout param to override the default 10s on ReceiveMessageRequest

### DIFF
--- a/src/main/scala/com/kifi/franz/FakeSQSQueue.scala
+++ b/src/main/scala/com/kifi/franz/FakeSQSQueue.scala
@@ -19,6 +19,7 @@ trait FakeSQSQueue[T] extends SQSQueue[T] {
 
   override def send(msg: T, messageAttributes: Option[Map[String,String]], delay: Option[Int] = None): Future[MessageId] = Future.successful(MessageId(""))
 
-  override protected def nextBatchRequestWithLock(maxBatchSize: Int, lockTimeout: FiniteDuration): Future[Seq[SQSMessage[T]]] = Future.successful(Seq.empty)
+  override protected def nextBatchRequestWithLock(maxBatchSize: Int, lockTimeout: FiniteDuration, waitTimeout: FiniteDuration): Future[Seq[SQSMessage[T]]] =
+    Future.successful(Seq.empty)
 
 }


### PR DESCRIPTION
# Changed
This adds a `waitTimeout` parameter to the message receiving APIs. It's defaulted to 10s (the current hardcoded value) in the method signatures for backwards compatibility. 